### PR TITLE
Upgrade internal packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@types/node": "^22.10.7",
-        "soap": "^1.1.7"
+        "soap": "^1.1.10"
       },
       "devDependencies": {
         "ts-node": "^10.9.2",
-        "typescript": "^5.7.3"
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -159,9 +159,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -411,13 +411,13 @@
       "license": "ISC"
     },
     "node_modules/soap": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/soap/-/soap-1.1.7.tgz",
-      "integrity": "sha512-zKNMtlZhnqhW0jv5z8qVE5A/1Vw/HKXnIFe2bss8s/+tqub4uLU9r20A4mTfiluePHABvm7p2YQjyvFBJjIf9A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/soap/-/soap-1.1.10.tgz",
+      "integrity": "sha512-dqfX9qHhXup3ZLWsI5of6xJIJKeBCPnn3tTu9sKtASm2A53Zk6/u3drygLiUy+H1mmjRBptXfVkjY6pt8nhOjA==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.9",
-        "axios-ntlm": "^1.4.2",
+        "axios": "^1.8.3",
+        "axios-ntlm": "^1.4.3",
         "debug": "^4.4.0",
         "formidable": "^3.5.2",
         "get-stream": "^6.0.1",
@@ -425,10 +425,10 @@
         "sax": "^1.4.1",
         "strip-bom": "^3.0.0",
         "whatwg-mimetype": "4.0.0",
-        "xml-crypto": "^6.0.0"
+        "xml-crypto": "^6.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/strip-bom": {
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -527,9 +527,9 @@
       "license": "ISC"
     },
     "node_modules/xml-crypto": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
-      "integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.1.tgz",
+      "integrity": "sha512-v05aU7NS03z4jlZ0iZGRFeZsuKO1UfEbbYiaeRMiATBFs6Jq9+wqKquEMTn4UTrYZ9iGD8yz3KT4L9o2iF682w==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/is-dom-node": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "license": "ISC",
   "dependencies": {
     "@types/node": "^22.10.7",
-    "soap": "^1.1.7"
+    "soap": "^1.1.10"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.2"
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `package.json` file to upgrade dependencies to their latest versions.

Dependency updates:

* Upgraded `soap` from version `^1.1.7` to `^1.1.10`
* Upgraded `typescript` from version `^5.7.3` to `^5.8.2`

## Fixes ( Vulnerabilities )
https://github.com/quipuapp/vnif-soap-client-nodejs/security/dependabot/2
https://github.com/quipuapp/vnif-soap-client-nodejs/security/dependabot/1